### PR TITLE
Pitboss-ng

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules
+src

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-Status](https://secure.travis-ci.org/mdp/pitboss.png)](http://travis-ci.org/mdp/pitboss)
+Status](https://secure.travis-ci.org/apiaryio/pitboss.png)](http://travis-ci.org/apiaryio/pitboss)
 
 ![Pitboss](http://s3.amazonaws.com/img.mdp.im/renobankclubinside4.jpg_%28705%C3%97453%29-20120923-100859.jpg)
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "pitboss",
+  "name": "pitboss-ng",
   "version": "0.1.5",
-  "description": "Runs untrusted code in a seperate process using Node VM",
+  "description": "Runs untrusted code in a seperate process using Node VM. Fork original pitboss with support coffee-script 1.8+",
   "keywords": [
     "sandbox",
     "untrusted code"
   ],
-  "repository": "git://github.com/mdp/pitboss.git",
-  "author": "Mark Percival <mark@markpercival.us> (http://markpercival.us)",
+  "repository": "git://github.com/apiaryio/pitboss.git",
+  "bugs": {
+    "url": "https://github.com/apiaryio/pitboss/issues"
+  },
+  "author": "Apiary Inc <support@apiary.io>",
   "scripts": {
-    "build": "rm -rf lib && coffee --bare --compile --output lib/ src/",
-    "postinstall": "rm -rf lib && coffee --bare --compile --output lib/ src/",
-    "test": "rm -rf lib && coffee --compile -o lib/ src/ && mocha --no-colors --compilers coffee:coffee-script/register test/*_test.coffee",
-    "prepublish": "rm -rf lib && coffee --compile -o lib/ src/"
+    "prepublish": "./scripts/compile",
+    "test": "./scripts/test"
   },
   "dependencies": {
     "coffee-script": "~1.8.0"

--- a/scripts/compile
+++ b/scripts/compile
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Running ./scripts/compile"
+if [ -d "src/" ]; then
+  rm -fr lib/
+  node_modules/.bin/coffee -b -c -o lib/ src/
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,4 @@
+#!/bin/bash
+./scripts/compile
+echo "Running ./scripts/test"
+mocha --no-colors --compilers coffee:coffee-script/register test/*_test.coffee


### PR DESCRIPTION
Remove installation from github. 

- Direct install from npm registry. 
- Remove post-install step and coffee from package.