### PR TITLE
Flaky tests fixed, pitboss.kill to actually kill fork, use pidusage package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "./scripts/test"
   },
   "dependencies": {
-    "clone": "^1.0.2"
+    "clone": "^1.0.2",
+    "pidusage": "^0.1.1"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/src/forkable.coffee
+++ b/src/forkable.coffee
@@ -17,18 +17,20 @@ process.on 'message', (msg) ->
     create(msg['code'])
   else
     run(msg)
+  return
 
 create = (code) ->
-  code = "\"use strict\";\n#{code}"
+  codeForVm = "\"use strict\";\n#{code}"
   try
     if vm.Script
-      script = new vm.Script code, {filename: 'sandbox'}
+      script = new vm.Script codeForVm, {filename: 'sandbox'}
     else
-      script = vm.createScript(code)
+      script = vm.createScript(codeForVm)
   catch err
     # Fatal, never try again
     errorStatus = STATUS['FATAL']
     errorStatusMsg = "VM Syntax Error: #{err}"
+  return
 
 run = (msg) ->
   if isFatalError()
@@ -57,6 +59,7 @@ run = (msg) ->
     message(res)
   catch err
     error "VM Runtime Error: #{err}", msg.id
+  return
 
 isFatalError = ->
   if errorStatus == STATUS['FATAL']

--- a/src/pitboss-ng.coffee
+++ b/src/pitboss-ng.coffee
@@ -2,31 +2,32 @@ path = require 'path'
 {fork, exec} = require 'child_process'
 {EventEmitter}  = require 'events'
 
-exports.Pitboss = class Pitboss extends EventEmitter
+exports.Pitboss = class Pitboss
   constructor: (code, options) ->
     @runner = new Runner(code, options)
-    @runner.on 'completed', =>
-      @next()
-    @q = []
+    @queue = []
+    @runner.on 'completed', @next.bind(@)
 
   run: ({context, libraries}, callback) ->
-    @q.push({context: context, libraries: libraries, callback: callback})
+    @queue.push({context: context, libraries: libraries, callback: callback})
     @next()
+    return
 
   next: ->
     return false if @runner.running
-    c = @q.shift()
+    c = @queue.shift()
     if c
       @runner.run({context: c.context, libraries: c.libraries}, c.callback)
+    return
 
 # Can only run one at a time due to the blocking nature of VM
 # Need to queue this up outside of the process since it's over an async channel
 exports.Runner = class Runner extends EventEmitter
   constructor: (@code, @options) ->
     @options ||= {}
+    @options.memoryLimit ||= 64*1024 # memoryLimit is in kBytes, so 64 MB here
     @options.timeout ||= 500
     @options.heartBeatTick ||= 100
-    @options.memoryLimit ||= 1024*1024
     unless @options.rssizeCommand
       if process.platform is 'darwin'
         @options.rssizeCommand = 'ps -p PID -o rss='
@@ -35,15 +36,17 @@ exports.Runner = class Runner extends EventEmitter
     @launchFork()
     @running = false
     @callback = null
+    super()
 
   launchFork: ->
-    @proc = fork(path.join(__dirname, '../lib/forkable.js'), [], {cwd: path.join(__dirname, '..')})
+    @proc = fork(path.join(__dirname, '../lib/forkable.js'))
     @proc.on 'message', @messageHandler
     @proc.on 'exit', @failedForkHandler
     @rssizeCommand = @options.rssizeCommand.replace('PID',@proc.pid)
     @proc.send {code: @code, timeout: (@options.timeout + 100)}
+    return
 
-  run: ({context, libraries}, callback) ->
+  run: ({context, libraries}, callback) =>
     return false if @running
     id = Date.now().toString() + Math.floor(Math.random() * 1000)
     msg =
@@ -56,23 +59,28 @@ exports.Runner = class Runner extends EventEmitter
     @proc.send msg
     id
 
-  disconnect: ->
+  disconnect: =>
     @proc.disconnect() if @proc and @proc.connected
+    return
 
   kill: ->
     @proc.kill("SIGKILL") if @proc and @proc.connected
     @closeTimer()
+    return
 
   messageHandler: (msg) =>
     @running = false
     @closeTimer()
     @emit 'result', msg
     if @callback
+      cb = @callback
+      @callback = false
       if msg.error
-        @callback(msg.error)
+        cb(msg.error)
       else
-        @callback(null, msg.result)
+        cb(null, msg.result)
     @notifyCompleted()
+    return
 
   failedForkHandler: =>
     @running = false
@@ -81,11 +89,13 @@ exports.Runner = class Runner extends EventEmitter
     error = @currentError || "Process Failed"
     @emit 'failed', error
     @callback(error) if @callback
-    @notifyCompleted() if @callback
+    @notifyCompleted()
+    return
 
   timeout: =>
     @currentError ?= "Timedout"
     @kill()
+    return
 
   memoryExceeded: =>
     exec @rssizeCommand, (err, stdout, stderr) =>
@@ -100,15 +110,23 @@ exports.Runner = class Runner extends EventEmitter
       return
     return
 
-  notifyCompleted: ->
+  notifyCompleted: =>
+    @running = false
     @emit 'completed'
+    return
 
   startTimer: ->
     @closeTimer()
     @timer = setTimeout(@timeout, @options['timeout'])
     @memoryTimer = setInterval(@memoryExceeded, @options['heartBeatTick'])
+    return
 
   closeTimer: ->
-    clearTimeout(@timer) if @timer
-    clearInterval(@memoryTimer) if @memoryTimer
+    if @timer
+      clearTimeout(@timer)
+      @timer = null
+    if @memoryTimer
+      clearInterval(@memoryTimer)
+      @memoryTimer = null
+    return
 

--- a/test/forkable_test.coffee
+++ b/test/forkable_test.coffee
@@ -11,8 +11,8 @@ describe "The forkable process", ->
     return
 
   afterEach ->
-    @runner?.proc?.removeAllListeners 'exit'
     @runner?.kill?()
+    @runner = null
     return
 
   describe "basic operation", ->

--- a/test/forkable_test.coffee
+++ b/test/forkable_test.coffee
@@ -137,37 +137,37 @@ describe "The forkable process", ->
 
     describe "from object for specifiyng context variable name", () ->
       beforeEach ->
-          @code = """
-            if(vmFooBar == undefined){
-              throw('vmFooBar is undefined');
-            }
-            null
-          """
+        @code = """
+          if(vmFooBar == undefined){
+            throw('vmFooBar is undefined');
+          }
+          null
+        """
 
-        it "should require and pass library to the context under variable with key name", (done) ->
-          @runner.on 'message', (msg) ->
-            assert.equal msg.id, "123"
-            assert.equal msg.result, null
-            assert.equal msg.error, null
-            done()
+      it "should require and pass library to the context under variable with key name", (done) ->
+        @runner.on 'message', (msg) ->
+          assert.equal msg.id, "123"
+          assert.equal msg.result, null
+          assert.equal msg.error, null
+          done()
 
-          @runner.send({code: @code}) # Setup
-          @runner.send({id: "123", context: {data:'foo'}, libraries: {'vmFooBar': 'vm'}}) # Setup
+        @runner.send({code: @code}) # Setup
+        @runner.send({id: "123", context: {data:'foo'}, libraries: {'vmFooBar': 'vm'}}) # Setup
 
     describe "from unintentional other type", () ->
       beforeEach ->
-          @code = """
-          var a = 'result'
-          a
-          """
+        @code = """
+        var a = 'result'
+        a
+        """
 
-        it "should raise and exception telling that it expects array or obejct", (done) ->
-          @runner.on 'message', (msg) ->
-            assert.equal msg.id, "1234"
-            assert.equal msg.result, undefined
-            assert.equal msg.error, "Pitboss error: Libraries must be defined by an array or by an object."
-            done()
+      it "should raise and exception telling that it expects array or obejct", (done) ->
+        @runner.on 'message', (msg) ->
+          assert.equal msg.id, "1234"
+          assert.equal msg.result, undefined
+          assert.equal msg.error, "Pitboss error: Libraries must be defined by an array or by an object."
+          done()
 
-          @runner.send({code: @code}) # Setup
-          @runner.send({id: "1234", context: {data:'foo'}, libraries: "vm"}) # Setup
+        @runner.send({code: @code}) # Setup
+        @runner.send({id: "1234", context: {data:'foo'}, libraries: "vm"}) # Setup
 

--- a/test/pitboss_test.coffee
+++ b/test/pitboss_test.coffee
@@ -15,7 +15,7 @@ describe "Pitboss running code", ->
     pitboss = new Pitboss(code)
 
   after ->
-    pitboss.runner.kill()
+    pitboss.kill()
 
   it "should take a JSON encodable message", (done) ->
     pitboss.run context: {data: "test"}, (err, result) ->
@@ -45,7 +45,7 @@ describe "Pitboss trying to access variables out of context", ->
     pitboss = new Pitboss(code)
 
   after ->
-    pitboss.runner.kill()
+    pitboss.kill()
 
   it "should not allow for context variables changes", (done) ->
 
@@ -67,7 +67,7 @@ describe "Pitboss modules loading code", ->
     pitboss = new Pitboss(code)
 
   afterEach ->
-    pitboss.runner.kill()
+    pitboss.kill()
 
   it "should not return an error when loaded module is used", (done) ->
     pitboss.run context: {data: "test"}, libraries: ['console'], (err, result) ->
@@ -97,8 +97,7 @@ describe "Running dubius code", ->
     pitboss = new Pitboss(code)
 
   after ->
-    pitboss.runner.kill()
-
+    pitboss.kill()
 
   it "should take a JSON encodable message", (done) ->
     pitboss.run context: {data: 123}, (err, result) ->
@@ -116,7 +115,7 @@ describe "Running shitty code", ->
     pitboss = new Pitboss(code)
 
   after ->
-    pitboss.runner.kill()
+    pitboss.kill()
 
   it "should return the error", (done) ->
     pitboss.run context: {data: 123}, (err, result) ->
@@ -140,7 +139,7 @@ describe "Running infinite loop code", ->
     """
 
   afterEach ->
-    runner.kill()
+    runner.kill(1)
     runner = null
 
   it "should timeout and restart fork", (done) ->
@@ -164,14 +163,13 @@ describe "Running infinite loop code", ->
         assert.equal "OK", result
         done()
 
-    # trigger manual kill
+    # trigger manual process kill
     runner.proc.kill('SIGKILL')
     return
 
 
 describe "Running code which causes memory leak", ->
   runner = null
-  doneCalled = false
 
   before ->
     code = """
@@ -188,11 +186,9 @@ describe "Running code which causes memory leak", ->
       memoryLimit: 1024*100
 
   after ->
-    runner?.kill()
+    runner.kill(1)
 
   it "should end with MemoryExceeded error", (done) ->
     runner.run context: {infinite: true}, (err, result) ->
       assert.equal "MemoryExceeded", err
-      if not doneCalled
-        doneCalled = true
-        return done()
+      return done()


### PR DESCRIPTION
- use `pidusage` (cross-platform process memory/cpu usage)
- add `pitboss.kill` command to really kill any remnants (forked process)
- clean-up during tests are run, do not keep forks running (no more ghosts)